### PR TITLE
Detect non-implemented COM interface methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # IFileOperation- a simple wrapper to use Windows shell file operations.
 This is a very small wrapper around IFileOperation to expose methods to perform file opereration (
-move, copy, rename, new, delete) on files using Windows shell operations.  This means these
+move, copy, rename, delete) on files using Windows shell operations.  This means these
 operations can be undone, files can be recycled, and you can allow users to handle name conflicts:
 just like when you do any of these through Windows Explorer.
 
@@ -14,7 +14,6 @@ At the moment this is a very young and so only exposes the file operations:
 - Move
 - Copy
 - Rename
-- New
 - Delete
 
 More features may be added in the future, feel free to open a feature request for something
@@ -182,3 +181,7 @@ request and you'll get feedback!
 
 If you're not into coding, you can open a [Bug Report or Feature Request](https://github.com/lojack5/IFileOperation/issues)
 and I'll look into it.
+
+
+## Known Issues:
+1. Incompatible with WINE: see: https://github.com/lojack5/IFileOperation/issues/9

--- a/ifileoperation/__init__.py
+++ b/ifileoperation/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'lojack5'
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 
 from .errors import *

--- a/ifileoperation/com/common.py
+++ b/ifileoperation/com/common.py
@@ -11,7 +11,12 @@ from typing import Callable, ParamSpec, TypeVar
 import pythoncom
 from comtypes import COMObject, IUnknown
 
-from ..errors import FileOperatorError, IFO_NotADirectoryError, UserCancelledError
+from ..errors import (
+    FileOperatorError,
+    IFO_NotADirectoryError,
+    InterfaceNotImplementedError,
+    UserCancelledError,
+)
 from ..flags import FileOperationResult
 
 PIUnknown = POINTER(IUnknown)  # type: ignore
@@ -40,6 +45,7 @@ _hresult_to_exception = {
     FileOperationResult.E_ALREADY_EXISTS_READONLY: FileExistsError,
     FileOperationResult.E_ALREADY_EXISTS_SYSTEM: FileExistsError,
     FileOperationResult.E_USER_CANCELLED: UserCancelledError,
+    FileOperationResult.E_NOT_IMPLEMENTED: InterfaceNotImplementedError,
     # NOTE: FileNotFound handled by parse_name
 }
 

--- a/ifileoperation/errors.py
+++ b/ifileoperation/errors.py
@@ -2,6 +2,7 @@ __all__ = [
     'IFileOperationError',
     'FileOperatorError',
     'UserCancelledError',
+    'InterfaceNotImplementedError',
     # Backwards compatible exceptions:
     'IFO_NotADirectoryError',
 ]
@@ -16,6 +17,14 @@ def int32_to_uint32(value: int) -> int:
 
 class IFileOperationError(Exception):
     pass
+
+
+class InterfaceNotImplementedError(IFileOperationError):
+    def __init__(self) -> None:
+        super().__init__(
+            'COM interface method not implemented.  This is likely a WINE bug, see: '
+            'https://bugs.winehq.org/show_bug.cgi?id=50064.'
+        )
 
 
 class FileOperatorError(IFileOperationError):
@@ -40,5 +49,3 @@ class UserCancelledError(IFileOperationError):
 # based exceptions with standard library exceptions
 class IFO_NotADirectoryError(FileOperatorError, NotADirectoryError):
     """FileOperatorError with HRESULT E_DRIVE_NOT_FOUND"""
-
-    pass

--- a/ifileoperation/fileoperator.py
+++ b/ifileoperation/fileoperator.py
@@ -69,9 +69,6 @@ class ProgressSink(FileOperationProgressSink):
         new_name: str | None,
         result: int,
     ) -> None:
-        import struct
-
-        result = struct.unpack('I', struct.pack('i', result))[0]
         if new_name:
             self.name_map[source] = new_name
 
@@ -113,6 +110,7 @@ class FileOperator:
     prompt if necessary.  If errors occur, the operation will fail immediately.
     """
 
+    @convert_exceptions
     def __init__(
         self,
         parent=None,

--- a/ifileoperation/flags.py
+++ b/ifileoperation/flags.py
@@ -304,3 +304,6 @@ class FileOperationResult(IntEnum):
 
     E_DRIVE_NOT_FOUND = 0x8027000F  # COPYENGINE_E_DEST_IS_RO_CD
     """The destination is a read-only CD, or the drive was not found."""
+
+    E_NOT_IMPLEMENTED = 0x80004001
+    """The method is not implemented."""


### PR DESCRIPTION
Under #9 

Raises an easier-to-deal-with exception when the OS hasn't implemented IFileOperation (ex: WINE).

Notes the incompatibility in the readme, also bump as a bugfix version.