### PR TITLE
Detect calling `commit` on a `FileOperator` with no operations queued

### DIFF
--- a/ifileoperation/__init__.py
+++ b/ifileoperation/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'lojack5'
-__version__ = '1.2.2'
+__version__ = '1.2.3'
 
 
 from .errors import *

--- a/ifileoperation/com/common.py
+++ b/ifileoperation/com/common.py
@@ -15,6 +15,7 @@ from ..errors import (
     FileOperatorError,
     IFO_NotADirectoryError,
     InterfaceNotImplementedError,
+    UnexpectedError,
     UserCancelledError,
 )
 from ..flags import FileOperationResult
@@ -46,6 +47,7 @@ _hresult_to_exception = {
     FileOperationResult.E_ALREADY_EXISTS_SYSTEM: FileExistsError,
     FileOperationResult.E_USER_CANCELLED: UserCancelledError,
     FileOperationResult.E_NOT_IMPLEMENTED: InterfaceNotImplementedError,
+    FileOperationResult.E_UNEXPECTED: UnexpectedError,
     # NOTE: FileNotFound handled by parse_name
 }
 

--- a/ifileoperation/errors.py
+++ b/ifileoperation/errors.py
@@ -52,6 +52,11 @@ class UserCancelledError(IFileOperationError):
         super().__init__('User cancelled the operation')
 
 
+class UnexpectedError(IFileOperationError):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(f'An unexpected error occurred: {args}, {kwargs}')
+
+
 # Backward Campatible exceptions: remove these in the next major version (2.0)
 # These are for backwards campatibility when replacing specific HRESULT
 # based exceptions with standard library exceptions

--- a/ifileoperation/flags.py
+++ b/ifileoperation/flags.py
@@ -307,3 +307,6 @@ class FileOperationResult(IntEnum):
 
     E_NOT_IMPLEMENTED = 0x80004001
     """The method is not implemented."""
+
+    E_UNEXPECTED = 0x8000FFFF
+    """An unexpected error occurred."""


### PR DESCRIPTION
- Default Windows API return HRESULT E_UNEXPECTED, which pywin32 converts to an exception
- Implements catching this case and converting to a noop