### PR TITLE
add another missing file not found error code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.12
+        language_version: python3.11
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/ifileoperation/__init__.py
+++ b/ifileoperation/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'lojack5'
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 
 
 from .errors import *

--- a/ifileoperation/com/filesysbinddata.py
+++ b/ifileoperation/com/filesysbinddata.py
@@ -47,7 +47,7 @@ def create_bind_ctx(find_data: WIN32_FIND_DATAW):
 FOLDER_BIND_CTX = create_bind_ctx(WIN32_FIND_DATAW(DWORD(FileAttributeFlags.DIRECTORY)))
 
 
-E_FILE_NOT_FOUND = -2147024894
+E_FILE_NOT_FOUND = (-2147024894, -2147024893)
 
 
 def parse_filename(path: StrPath, force: bool = False):
@@ -60,7 +60,7 @@ def parse_filename(path: StrPath, force: bool = False):
             path, None, shell.IID_IShellItem2  # type: ignore
         )
     except pywintypes.com_error as e:
-        if e.hresult == E_FILE_NOT_FOUND:  # type: ignore
+        if e.hresult in E_FILE_NOT_FOUND:  # type: ignore
             if force:
                 return shell.SHCreateItemFromParsingName(
                     path, FOLDER_BIND_CTX, shell.IID_IShellItem2


### PR DESCRIPTION
Yet another Win API error code that means "file not found"
- set pre-commit python version to 3.11 (pre-commit needs an update to work on 3.12, pkgutil.ImpImporter was removed)